### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In a Meteor app directory, enter:
 
 ```bash
 $ meteor add twbs:bootstrap
-$ meteor add tsega:bootstrap3-datetimepicker@=3.1.3_3
+$ meteor add tsega:bootstrap3-datetimepicker
 $ meteor add aldeed:autoform
 ```
 


### PR DESCRIPTION
On the original package there needs to be a version constraint on the bootstrap3-datetimepicker package. However, with this updated version, no version constraint is necessary.
